### PR TITLE
SuperSecret assumeSecretWillExist transformer

### DIFF
--- a/kustomize/plugin/qlik.com/v1/supersecret/README.md
+++ b/kustomize/plugin/qlik.com/v1/supersecret/README.md
@@ -1,9 +1,10 @@
 # SuperSecret Kustomize Plugin
 
-## Using as a transformer:
+## Using as a transformer when the target secret exists in the input stream:
 
 When used as a `transformer`, the plugin will optionally append a name suffix hash for the specified secret unless specifically disabled by setting `disableNameSuffixHash: true`.
-It will also optionally append data to the secret from the contents of the `stringData` map. Name suffix hash is calculated after any updates to the secret's data.   
+It will also optionally append data to the secret from the contents of the `stringData` map. Name suffix hash is calculated after any updates to the secret's data. 
+If the name was changed, the references to that name in other resources will be updated.   
 
 Create a layout that looks like this:
 ```text
@@ -118,6 +119,103 @@ spec:
       - name: foo
         secret:
           secretName: my-secret-b22th6mh4g
+```
+
+## Using as a transformer when the target secret DOES NOT exist in the input stream:
+
+If the target secret resource does not exist in the input stream and `assumeSecretWillExist: true`, 
+then the plugin will attempt to update the references to that name in other resources based on the hash of the data in the `stringData` map. 
+
+Create a layout that looks like this:
+```text
+tree .
+.
+├── deployment.yaml
+├── kustomization.yaml
+├── secretTransformer.yaml
+```
+
+```bash
+cat <<'EOF' >kustomization.yaml
+resources:
+- deployment.yaml
+
+transformers:
+- secretTransformer.yaml
+EOF
+```
+
+```bash
+cat <<'EOF' >deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: my-pod
+        image: some-image
+        volumeMounts:
+        - name: foo
+          mountPath: "/etc/foo"
+          readOnly: true
+      volumes:
+      - name: foo
+        secret:
+          secretName: my-secret
+EOF
+```
+
+```bash
+cat <<'EOF' >secretTransformer.yaml
+apiVersion: qlik.com/v1
+kind: SuperSecret
+metadata:
+  name: my-secret
+stringData:
+  foo: bar
+  baz: whatever
+assumeSecretWillExist: true
+EOF
+```
+
+Get and build the plugins:
+```bash
+git clone git@github.com:qlik-oss/kustomize-plugins.git
+pushd kustomize-plugins
+make install
+popd
+```
+
+Then run `kustomize` on the directory:
+```bash
+XDG_CONFIG_HOME=kustomize-plugins $HOME/go/bin/kustomize build --enable_alpha_plugins .
+```
+
+The output will look like so:
+```text
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - image: some-image
+        name: my-pod
+        volumeMounts:
+        - mountPath: /etc/foo
+          name: foo
+          readOnly: true
+      volumes:
+      - name: foo
+        secret:
+          secretName: my-secret-k8gb8gd84f
 ```
 
 ## Using as a generator:

--- a/kustomize/plugin/qlik.com/v1/supersecret/README.md
+++ b/kustomize/plugin/qlik.com/v1/supersecret/README.md
@@ -78,7 +78,6 @@ Get and build the plugins:
 ```bash
 git clone git@github.com:qlik-oss/kustomize-plugins.git
 pushd kustomize-plugins
-git checkout SecretHashTransformer
 make install
 popd
 ```
@@ -186,7 +185,6 @@ Get and build the plugins:
 ```bash
 git clone git@github.com:qlik-oss/kustomize-plugins.git
 pushd kustomize-plugins
-git checkout SecretHashTransformer
 make install
 popd
 ```

--- a/kustomize/plugin/qlik.com/v1/supersecret/SuperSecret.go
+++ b/kustomize/plugin/qlik.com/v1/supersecret/SuperSecret.go
@@ -52,7 +52,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 	secretResource := p.findSecretByName(p.Name, m)
 	if secretResource != nil {
 		return p.executeBasicSecretTransform(secretResource, m)
-	} else if p.AssumeSecretWillExist && !p.DisableNameSuffixHash {
+	} else if p.AssumeSecretWillExist && !p.DisableNameSuffixHash && len(p.StringData) > 0 {
 		return p.executeAssumeSecretWillExistTransform(m)
 	}
 	return nil

--- a/kustomize/plugin/qlik.com/v1/supersecret/SuperSecret.go
+++ b/kustomize/plugin/qlik.com/v1/supersecret/SuperSecret.go
@@ -4,22 +4,21 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
-
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
 	"sigs.k8s.io/kustomize/v3/plugin/builtin"
 
 	"github.com/qlik-oss/kustomize-plugins/kustomize/utils"
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
-	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
-
 	"sigs.k8s.io/yaml"
 )
 
 type plugin struct {
-	hasher     ifc.KunstructuredHasher
-	StringData map[string]string `json:"stringData,omitempty" yaml:"stringData,omitempty"`
+	hasher                ifc.KunstructuredHasher
+	StringData            map[string]string `json:"stringData,omitempty" yaml:"stringData,omitempty"`
+	AssumeSecretWillExist bool              `json:"assumeSecretWillExist,omitempty" yaml:"assumeSecretWillExist,omitempty"`
 	builtin.SecretGeneratorPlugin
 }
 
@@ -50,37 +49,88 @@ func (p *plugin) Generate() (resmap.ResMap, error) {
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
+	secretResource := p.findSecretByName(p.Name, m)
+	if secretResource != nil {
+		return p.executeBasicSecretTransform(secretResource, m)
+	} else if p.AssumeSecretWillExist && !p.DisableNameSuffixHash {
+		return p.executeAssumeSecretWillExistTransform(m)
+	}
+	return nil
+}
+
+func (p *plugin) executeAssumeSecretWillExistTransform(m resmap.ResMap) error {
+	generateResourceMap, err := p.Generate()
+	if err != nil {
+		logger.Printf("error generating temp secret: %v, error: %v\n", p.Name, err)
+		return err
+	}
+	secretResource := p.findSecretByName(p.Name, generateResourceMap)
+	if secretResource == nil {
+		err := fmt.Errorf("error locating generated temp secret: %v", p.Name)
+		logger.Printf("%v\n", err)
+		return err
+	}
+	err = m.Append(secretResource)
+	if err != nil {
+		logger.Printf("error appending temp secret: %v to the resource map, error: %v\n", p.Name, err)
+		return err
+	}
+	updatedSecretName, err := p.generateNameWithHash(secretResource)
+	if err != nil {
+		logger.Printf("error hashing secret resource contents for secretName: %v, error: %v\n", p.Name, err)
+		return err
+	}
+	secretResource.SetName(updatedSecretName)
+	err = p.executeNameReferencesTransformer(m)
+	if err != nil {
+		logger.Printf("error executing nameReferenceTransformer.Transform(): %v\n", err)
+		return err
+	}
+	err = m.Remove(secretResource.CurId())
+	if err != nil {
+		logger.Printf("error removing temp secret: %v from the resource map, error: %v\n", p.Name, err)
+		return err
+	}
+	return nil
+}
+
+func (p *plugin) executeBasicSecretTransform(secretResource *resource.Resource, m resmap.ResMap) error {
 	var updatedSecretName string
 	var err error
-
-	for _, res := range m.Resources() {
-		if res.GetKind() == "Secret" && res.GetName() == p.Name {
-			if err := p.appendDataToSecret(res, p.StringData); err != nil {
-				logger.Printf("error appending data to secret with secretName: %v, error: %v\n", p.Name, err)
-				return err
-			}
-			if !p.DisableNameSuffixHash {
-				updatedSecretName, err = p.generateNameWithHash(res)
-				if err != nil {
-					logger.Printf("error hashing secret resource contents for secretName: %v, error: %v\n", p.Name, err)
-					return err
-				}
-				res.SetName(updatedSecretName)
-			}
-			break
-		}
+	if err := p.appendDataToSecret(secretResource, p.StringData); err != nil {
+		logger.Printf("error appending data to secret with secretName: %v, error: %v\n", p.Name, err)
+		return err
 	}
-
+	if !p.DisableNameSuffixHash {
+		updatedSecretName, err = p.generateNameWithHash(secretResource)
+		if err != nil {
+			logger.Printf("error hashing secret resource contents for secretName: %v, error: %v\n", p.Name, err)
+			return err
+		}
+		secretResource.SetName(updatedSecretName)
+	}
 	if len(updatedSecretName) > 0 {
-		defaultTransformerConfig := config.MakeDefaultConfig()
-		nameReferenceTransformer := transformers.NewNameReferenceTransformer(defaultTransformerConfig.NameReference)
-		err := nameReferenceTransformer.Transform(m)
+		err := p.executeNameReferencesTransformer(m)
 		if err != nil {
 			logger.Printf("error executing nameReferenceTransformer.Transform(): %v\n", err)
 			return err
 		}
 	}
+	return nil
+}
 
+func (p *plugin) executeNameReferencesTransformer(m resmap.ResMap) error {
+	defaultTransformerConfig := config.MakeDefaultConfig()
+	nameReferenceTransformer := transformers.NewNameReferenceTransformer(defaultTransformerConfig.NameReference)
+	return nameReferenceTransformer.Transform(m)
+}
+
+func (p *plugin) findSecretByName(name string, m resmap.ResMap) *resource.Resource {
+	for _, res := range m.Resources() {
+		if res.GetKind() == "Secret" && res.GetName() == p.Name {
+			return res
+		}
+	}
 	return nil
 }
 

--- a/kustomize/plugin/qlik.com/v1/supersecret/SuperSecret_test.go
+++ b/kustomize/plugin/qlik.com/v1/supersecret/SuperSecret_test.go
@@ -288,6 +288,103 @@ stringData:
 	}
 }
 
+func TestSuperSecret_assumeSecretWillExistTransformer(t *testing.T) {
+	pluginInputResources := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: myPod
+        image: some-image
+        volumeMounts:
+        - name: foo
+          mountPath: "/etc/foo"
+          readOnly: true
+      volumes:
+      - name: foo
+        secret:
+          secretName: mySecret
+`
+	testCases := []struct {
+		name                 string
+		pluginConfig         string
+		pluginInputResources string
+		checkAssertions      func(*testing.T, resmap.ResMap)
+	}{
+		{
+			name: "withHash_withStringData",
+			pluginConfig: `
+apiVersion: qlik.com/v1
+kind: SuperSecret
+metadata:
+  name: mySecret
+stringData:
+  foo: bar
+  baz: whatever
+assumeSecretWillExist: true
+`,
+			pluginInputResources: pluginInputResources,
+			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
+				for _, res := range resMap.Resources() {
+					if res.GetKind() == "Secret" {
+						assert.FailNow(t, "secret should not be present in the stream")
+						break
+					}
+				}
+
+				foundDeployment := false
+				for _, res := range resMap.Resources() {
+					if res.GetKind() == "Deployment" {
+						foundDeployment = true
+
+						value, err := res.GetFieldValue("spec.template.spec.volumes[0].secret.secretName")
+						assert.NoError(t, err)
+
+						match, err := regexp.MatchString("^mySecret-[0-9a-z]+$", value.(string))
+						assert.NoError(t, err)
+						assert.True(t, match)
+
+						break
+					}
+				}
+				assert.True(t, foundDeployment)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resourceFactory := resmap.NewFactory(resource.NewFactory(
+				kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+
+			resMap, err := resourceFactory.NewResMapFromBytes([]byte(testCase.pluginInputResources))
+			if err != nil {
+				t.Fatalf("Err: %v", err)
+			}
+
+			err = KustomizePlugin.Config(utils.NewFakeLoader("/"), resourceFactory, []byte(testCase.pluginConfig))
+			if err != nil {
+				t.Fatalf("Err: %v", err)
+			}
+
+			err = KustomizePlugin.Transform(resMap)
+			if err != nil {
+				t.Fatalf("Err: %v", err)
+			}
+
+			for _, res := range resMap.Resources() {
+				fmt.Printf("--res: %v\n", res.String())
+			}
+
+			testCase.checkAssertions(t, resMap)
+		})
+	}
+}
+
 func TestSuperSecret_generator(t *testing.T) {
 	testCases := []struct {
 		name                 string

--- a/kustomize/plugin/qlik.com/v1/supersecret/SuperSecret_test.go
+++ b/kustomize/plugin/qlik.com/v1/supersecret/SuperSecret_test.go
@@ -293,13 +293,33 @@ func TestSuperSecret_assumeSecretWillExistTransformer(t *testing.T) {
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: myDeployment
+  name: myDeployment1
 spec:
   replicas: 3
   template:
     spec:
       containers:
-      - name: myPod
+      - name: myPod1
+        image: some-image
+        volumeMounts:
+        - name: foo
+          mountPath: "/etc/foo"
+          readOnly: true
+      volumes:
+      - name: foo
+        secret:
+          secretName: mySecret
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: myPod2
         image: some-image
         volumeMounts:
         - name: foo
@@ -322,10 +342,10 @@ spec:
 apiVersion: qlik.com/v1
 kind: SuperSecret
 metadata:
-  name: mySecret
+ name: mySecret
 stringData:
-  foo: bar
-  baz: whatever
+ foo: bar
+ baz: whatever
 assumeSecretWillExist: true
 `,
 			pluginInputResources: pluginInputResources,
@@ -337,22 +357,104 @@ assumeSecretWillExist: true
 					}
 				}
 
-				foundDeployment := false
+				foundDeployments := map[string]bool {"myDeployment1" : false, "myDeployment2": false}
+				for _, deploymentName := range []string {"myDeployment1", "myDeployment2"} {
+					for _, res := range resMap.Resources() {
+						if res.GetKind() == "Deployment" && res.GetName() == deploymentName {
+							foundDeployments[deploymentName] = true
+
+							value, err := res.GetFieldValue("spec.template.spec.volumes[0].secret.secretName")
+							assert.NoError(t, err)
+
+							match, err := regexp.MatchString("^mySecret-[0-9a-z]+$", value.(string))
+							assert.NoError(t, err)
+							assert.True(t, match)
+
+							break
+						}
+					}
+				}
+				for deploymentName := range foundDeployments {
+					assert.True(t, foundDeployments[deploymentName])
+				}
+			},
+		},
+		{
+			name: "doesNothing_withoutHash",
+			pluginConfig: `
+apiVersion: qlik.com/v1
+kind: SuperSecret
+metadata:
+ name: mySecret
+stringData:
+ foo: bar
+ baz: whatever
+assumeSecretWillExist: true
+disableNameSuffixHash: true
+`,
+			pluginInputResources: pluginInputResources,
+			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
 				for _, res := range resMap.Resources() {
-					if res.GetKind() == "Deployment" {
-						foundDeployment = true
-
-						value, err := res.GetFieldValue("spec.template.spec.volumes[0].secret.secretName")
-						assert.NoError(t, err)
-
-						match, err := regexp.MatchString("^mySecret-[0-9a-z]+$", value.(string))
-						assert.NoError(t, err)
-						assert.True(t, match)
-
+					if res.GetKind() == "Secret" {
+						assert.FailNow(t, "secret should not be present in the stream")
 						break
 					}
 				}
-				assert.True(t, foundDeployment)
+
+				foundDeployments := map[string]bool {"myDeployment1" : false, "myDeployment2": false}
+				for _, deploymentName := range []string {"myDeployment1", "myDeployment2"} {
+					for _, res := range resMap.Resources() {
+						if res.GetKind() == "Deployment" && res.GetName() == deploymentName {
+							foundDeployments[deploymentName] = true
+
+							value, err := res.GetFieldValue("spec.template.spec.volumes[0].secret.secretName")
+							assert.NoError(t, err)
+							assert.Equal(t, "mySecret", value)
+
+							break
+						}
+					}
+				}
+				for deploymentName := range foundDeployments {
+					assert.True(t, foundDeployments[deploymentName])
+				}
+			},
+		},
+		{
+			name: "doesNothing_withoutStringData",
+			pluginConfig: `
+apiVersion: qlik.com/v1
+kind: SuperSecret
+metadata:
+  name: mySecret
+assumeSecretWillExist: true
+`,
+			pluginInputResources: pluginInputResources,
+			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
+				for _, res := range resMap.Resources() {
+					if res.GetKind() == "Secret" {
+						assert.FailNow(t, "secret should not be present in the stream")
+						break
+					}
+				}
+
+				foundDeployments := map[string]bool {"myDeployment1" : false, "myDeployment2": false}
+				for _, deploymentName := range []string {"myDeployment1", "myDeployment2"} {
+					for _, res := range resMap.Resources() {
+						if res.GetKind() == "Deployment" && res.GetName() == deploymentName {
+							foundDeployments[deploymentName] = true
+
+							value, err := res.GetFieldValue("spec.template.spec.volumes[0].secret.secretName")
+							assert.NoError(t, err)
+							assert.Equal(t, "mySecret", value)
+
+							break
+						}
+					}
+				}
+				for deploymentName := range foundDeployments {
+					assert.True(t, foundDeployments[deploymentName])
+				}
 			},
 		},
 	}


### PR DESCRIPTION
If the target secret resource does not exist in the input stream and `assumeSecretWillExist: true`, 
then the plugin will attempt to update the references to that name in other resources based on the hash of the data in the `stringData` map. 