### PR TITLE
Modify replicatedhq/troubleshoot github link to point to master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN GO111MODULE=on go get github.com/mikefarah/yq/v2
 
 # install troubleshoot for preflight checks
 RUN git clone https://github.com/replicatedhq/troubleshoot.git &&\
-    cd troubleshoot &&\
-    make preflight && ls -ltr bin && mv bin/preflight /go/bin &&\
+    cd troubleshoot && make preflight && ls -ltr bin && mv bin/preflight /go/bin &&\
     make support-bundle && ls -ltr bin && mv bin/support-bundle /go/bin &&\
     rm -rf troubleshoot
 RUN go get github.com/hairyhenderson/gomplate/cmd/gomplate

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,6 @@ ENV GO111MODULE=off
 
 RUN git clone https://github.com/ashwathishiva/troubleshoot.git; cd troubleshoot; git checkout custom_text_analyzer; make preflight; ls -ltr bin; mv bin/preflight /go/bin; echo "done moving preflight"; make support-bundle; ls -ltr bin; mv bin/support-bundle /go/bin; echo "done moving support-bundle"; rm -rf troubleshoot
 
-# RUN git clone https://github.com/bearium/troubleshoot.git; cd troubleshoot; git checkout stdout_results; make preflight; ls -ltr bin; mv bin/preflight /go/bin; echo "done moving preflight"
-    # rm -rf troubleshoot
-
-# RUN curl -Lo https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.0/preflight_0.19.0_linux_amd64-alpha.tar.gz
-# RUN tar xzvf preflight_0.9.0_linux_amd64-alpha.tar.gz
-# RUN mv bin/preflight /usr/local/bin
-
 RUN go get github.com/hairyhenderson/gomplate/cmd/gomplate
 RUN mv /go/bin/kustomize /go/bin/kustomize.cmd
 RUN mv /go/src/qlik-oss/kustomize-plugins/kustomize.wrapper /go/bin/kustomize

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ COPY . /go/src/qlik-oss/kustomize-plugins/
 RUN cd /go/src/qlik-oss/kustomize-plugins && make
 RUN find /go/src/qlik-oss/kustomize-plugins -name \*.so -exec cp --parents \{} /tmp \;
 RUN GO111MODULE=on go get github.com/mikefarah/yq/v2
-RUN git clone https://github.com/ashwathishiva/troubleshoot.git &&\
-    cd troubleshoot && git checkout custom_text_analyzer &&\
+
+# install troubleshoot for preflight checks
+RUN git clone https://github.com/replicatedhq/troubleshoot.git &&\
+    cd troubleshoot &&\
     make preflight && ls -ltr bin && mv bin/preflight /go/bin &&\
     make support-bundle && ls -ltr bin && mv bin/support-bundle /go/bin &&\
     rm -rf troubleshoot

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,16 @@ RUN cd /go/src/qlik-oss/kustomize-plugins && make
 RUN find /go/src/qlik-oss/kustomize-plugins -name \*.so -exec cp --parents \{} /tmp \;
 RUN go get github.com/mikefarah/yq@2.4.1
 ENV GO111MODULE=off
+
+RUN git clone https://github.com/ashwathishiva/troubleshoot.git; cd troubleshoot; git checkout custom_text_analyzer; make preflight; ls -ltr bin; mv bin/preflight /go/bin; echo "done moving preflight"; make support-bundle; ls -ltr bin; mv bin/support-bundle /go/bin; echo "done moving support-bundle"; rm -rf troubleshoot
+
+# RUN git clone https://github.com/bearium/troubleshoot.git; cd troubleshoot; git checkout stdout_results; make preflight; ls -ltr bin; mv bin/preflight /go/bin; echo "done moving preflight"
+    # rm -rf troubleshoot
+
+# RUN curl -Lo https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.0/preflight_0.19.0_linux_amd64-alpha.tar.gz
+# RUN tar xzvf preflight_0.9.0_linux_amd64-alpha.tar.gz
+# RUN mv bin/preflight /usr/local/bin
+
 RUN go get github.com/hairyhenderson/gomplate/cmd/gomplate
 RUN mv /go/bin/kustomize /go/bin/kustomize.cmd
 RUN mv /go/src/qlik-oss/kustomize-plugins/kustomize.wrapper /go/bin/kustomize


### PR DESCRIPTION
This PR contains a small change to point to the master branch of the replicatedhq/troubleshoot repository instead of my branch. 

I'm able to test this change successfully in my local setup. 